### PR TITLE
Update src/test/scala/net/fwbrasil/radon/ref/RefSpecs.scala

### DIFF
--- a/src/test/scala/net/fwbrasil/radon/ref/RefSpecs.scala
+++ b/src/test/scala/net/fwbrasil/radon/ref/RefSpecs.scala
@@ -22,13 +22,14 @@ class RefSpecs extends Specification {
 				val objRef = new Ref[Any]
 				val subSink: Sink[Any] = objRef
 				val superSink: Sink[String] = objRef
-
+                                // SPECS2: you can write 'ok' or 'success' instead 
 				true must beTrue // tautology
 			}
 
 			"set the value when crated" in transactional {
 				val ref = new Ref(100)
 				!ref must beEqualTo(100)
+				// SPECS2: you can also write ref.get must beSome(100)
 				ref.get must beEqualTo(Some(100))
 			}
 
@@ -42,6 +43,7 @@ class RefSpecs extends Specification {
 				val ref2 = new Ref(100)
 				ref2.put(None)
 				!ref2 must beEqualTo(0)
+				// SPECS2: you can also write ref2.get must beNone
 				ref2.get must beEqualTo(None)
 			}
 


### PR DESCRIPTION
more comments on the specification, I can see that you indeed know about the 'throwA' matcher!
